### PR TITLE
Don't attempt to close nil channels

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -255,7 +255,9 @@ fmt.Printf( "closeAllChannels\n" )
       if l.Debug {
          fmt.Printf( "Closing channel for MessageID %d\n", MessageID );
       }
-      close( Channel )
+      if Channel != nil {
+         close( Channel )
+      }
       l.chanResults[ MessageID ] = nil
    }
    close( l.chanMessageID )


### PR DESCRIPTION
This avoids a crash when attempting to close a nil Channel. A stack trace of the problem can be seen here: http://pastebin.com/HEb7Duiy

I have no idea if this is the truly proper solution, or if there's a deeper bug, but this permits my program to run as it should, and return an error code to the caller, rather than crashing.
