### PR TITLE
Add newline to error messages

### DIFF
--- a/ldap.go
+++ b/ldap.go
@@ -283,7 +283,7 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("LDAP Result Code %d %q: %s", e.ResultCode, LDAPResultCodeMap[e.ResultCode], e.Err)
+	return fmt.Sprintf("LDAP Result Code %d %q: %s\n", e.ResultCode, LDAPResultCodeMap[e.ResultCode], e.Err)
 }
 
 func NewError(ResultCode uint8, Err error) *Error {


### PR DESCRIPTION
Otherwise in the output, the lines are all mashed together. E.g.:

```
LDAP Result Code 200 "": dial tcp: lookup ldapserver.mycompany.com: no such host2015-01-12T06:40:43.9663425-08:00 POST /users/me/tokens 500 in 12570.002621ms
```
