### PR TITLE
Fix syntax to work with current Go stdlib

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -30,13 +30,13 @@ func TestFilter(t *testing.T) {
 	for _, i := range test_filters {
 		filter, err := CompileFilter(i.filter_str)
 		if err != nil {
-			t.Errorf("Problem compiling %s - %s", err.String())
+			t.Errorf("Problem compiling %s - %s", i.filter_str, err)
 		} else if filter.Tag != uint8(i.filter_type) {
 			t.Errorf("%q Expected %q got %q", i.filter_str, FilterMap[uint64(i.filter_type)], FilterMap[uint64(filter.Tag)])
 		} else {
 			o, err := DecompileFilter(filter)
 			if err != nil {
-				t.Errorf("Problem compiling %s - %s", i, err.String())
+				t.Errorf("Problem compiling %s - %s", i.filter_str, err)
 			} else if i.filter_str != o {
 				t.Errorf("%q expected, got %q", i.filter_str, o)
 			}

--- a/ldap_test.go
+++ b/ldap_test.go
@@ -20,7 +20,7 @@ func TestConnect(t *testing.T) {
 	fmt.Printf("TestConnect: starting...\n")
 	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldap_server, ldap_port))
 	if err != nil {
-		t.Errorf(err.String())
+		t.Error(err)
 		return
 	}
 	defer l.Close()
@@ -31,7 +31,7 @@ func TestSearch(t *testing.T) {
 	fmt.Printf("TestSearch: starting...\n")
 	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldap_server, ldap_port))
 	if err != nil {
-		t.Errorf(err.String())
+		t.Error(err)
 		return
 	}
 	defer l.Close()
@@ -45,7 +45,7 @@ func TestSearch(t *testing.T) {
 
 	sr, err := l.Search(search_request)
 	if err != nil {
-		t.Errorf(err.String())
+		t.Error(err)
 		return
 	}
 
@@ -56,14 +56,14 @@ func TestSearchWithPaging(t *testing.T) {
 	fmt.Printf("TestSearchWithPaging: starting...\n")
 	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldap_server, ldap_port))
 	if err != nil {
-		t.Errorf(err.String())
+		t.Error(err)
 		return
 	}
 	defer l.Close()
 
 	err = l.Bind("", "")
 	if err != nil {
-		t.Errorf(err.String())
+		t.Error(err)
 		return
 	}
 
@@ -75,7 +75,7 @@ func TestSearchWithPaging(t *testing.T) {
 		nil)
 	sr, err := l.SearchWithPaging(search_request, 5)
 	if err != nil {
-		t.Errorf(err.String())
+		t.Error(err)
 		return
 	}
 
@@ -92,7 +92,7 @@ func testMultiGoroutineSearch(t *testing.T, l *Conn, results chan *SearchResult,
 	sr, err := l.Search(search_request)
 
 	if err != nil {
-		t.Errorf(err.String())
+		t.Error(err)
 		results <- nil
 		return
 	}
@@ -104,7 +104,7 @@ func TestMultiGoroutineSearch(t *testing.T) {
 	fmt.Printf("TestMultiGoroutineSearch: starting...\n")
 	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldap_server, ldap_port))
 	if err != nil {
-		t.Errorf(err.String())
+		t.Error(err)
 		return
 	}
 	defer l.Close()


### PR DESCRIPTION
Addresses errors such as:

./ldap_test.go:23: err.String undefined (type *Error has no field or method String)
