### PR TITLE
Fix erring parsing filter from JXplorer & Apache Directory Studio

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -124,7 +124,11 @@ func DecompileFilter(packet *ber.Packet) (ret string, err *Error) {
 		ret += "<="
 		ret += ber.DecodeString(packet.Children[1].Data.Bytes())
 	case FilterPresent:
-		ret += ber.DecodeString(packet.Children[0].Data.Bytes())
+		if len(packet.Children) > 0 {
+			ret += ber.DecodeString(packet.Children[0].Data.Bytes())
+		} else {
+			ret += ber.DecodeString(packet.Data.Bytes())
+		}
 		ret += "=*"
 	case FilterApproxMatch:
 		ret += ber.DecodeString(packet.Children[0].Data.Bytes())

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,13 +1,20 @@
 package ldap
 
 import (
-	"github.com/mmitton/asn1-ber"
+	"encoding/base64"
 	"testing"
+
+	"github.com/mmitton/asn1-ber"
 )
 
 type compile_test struct {
 	filter_str  string
 	filter_type int
+}
+
+type decompile_raw_test struct {
+	compiled_b64_str string
+	expected_str     string
 }
 
 var test_filters = []compile_test{
@@ -25,6 +32,10 @@ var test_filters = []compile_test{
 	// compile_test{ filter_str: "()", filter_type: FilterExtensibleMatch },
 }
 
+var raw_test_filters = []decompile_raw_test{
+	decompile_raw_test{compiled_b64_str: "hwtvYmplY3RjbGFzcw==", expected_str: "(objectclass=*)"},
+}
+
 func TestFilter(t *testing.T) {
 	// Test Compiler and Decompiler
 	for _, i := range test_filters {
@@ -40,6 +51,21 @@ func TestFilter(t *testing.T) {
 			} else if i.filter_str != o {
 				t.Errorf("%q expected, got %q", i.filter_str, o)
 			}
+		}
+	}
+}
+
+func TestDecompileFilter(t *testing.T) {
+	// Test decompiling real-world filters
+	for _, test := range raw_test_filters {
+		filterBytes, _ := base64.StdEncoding.DecodeString(test.compiled_b64_str)
+		filterPacket := ber.DecodePacket(filterBytes)
+		filterStr, err := DecompileFilter(filterPacket)
+		if err != nil {
+			t.Errorf("Problem decompiling %s - %s", test.compiled_b64_str, err)
+		}
+		if test.expected_str != filterStr {
+			t.Errorf("%s Expected %s got %s", test.compiled_b64_str, test.expected_str, filterStr)
 		}
 	}
 }


### PR DESCRIPTION
Fixes an issue decompiling filters sent across from both JXplorer and Apache Directory Studio.

Unit test included. Example failure:

--- FAIL: TestDecompileFilter (0.00s)
    filter_test.go:65: Problem decompiling hwtvYmplY3RjbGFzcw== - LDAP Result Code 202 "": Error decompiling filter
    filter_test.go:68: hwtvYmplY3RjbGFzcw== Expected (objectclass=*) got (
FAIL
