### PR TITLE
Remove stale references to BSD license

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-# Copyright 2009 The Go Authors. All rights reserved.
-# Use of this source code is governed by a BSD-style
-# license that can be found in the LICENSE file.
-
 include $(GOROOT)/src/Make.inc
 
 TARG=github.com/mmitton/ldap

--- a/bind.go
+++ b/bind.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 // File contains Bind functionality
 package ldap
 

--- a/conn.go
+++ b/conn.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 // This package provides LDAP client functions.
 package ldap
 

--- a/control.go
+++ b/control.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 // This package provides LDAP client functions.
 package ldap
 

--- a/filter.go
+++ b/filter.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 // File contains a filter compiler/decompiler
 package ldap
 

--- a/ldap.go
+++ b/ldap.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 // This package provides LDAP client functions.
 package ldap
 

--- a/search.go
+++ b/search.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 // File contains Search functionality
 package ldap
 


### PR DESCRIPTION
The repo was relicensed under MIT in 9031c63a92b917c423331f055304e168d8f28789 but individual files still referred to the BSD license.